### PR TITLE
Update datetime formatting

### DIFF
--- a/chexus/_impl/models.py
+++ b/chexus/_impl/models.py
@@ -65,16 +65,16 @@ class TableItem(object):
         self.attrs = kwargs
 
         for key, value in self.attrs.items():
-            value = self._sanitize_value(key, value) if value else value
+            value = self._sanitize_value(value) if value else value
 
             self.attrs[key] = value
 
             if not hasattr(self, key):
                 setattr(self, key, value)
 
-    def _sanitize_value(self, key, value):
+    def _sanitize_value(self, value):
         # Coerce any dates, times to standard format
-        value = self._valid_datetime(key, value)
+        value = self._valid_datetime(value)
 
         # Serialize any dictionaries
         if isinstance(value, dict):
@@ -83,22 +83,16 @@ class TableItem(object):
         return value
 
     @staticmethod
-    def _valid_datetime(key, value):
+    def _valid_datetime(value):
         try:
             # Parse string for datetime object
             naive_dt = dateutil.parser.parse(value, fuzzy=True)
-            # Make the datetime timezone-aware
+            # Make datetime timezone-aware
             aware_dt = pytz.timezone("US/Eastern").localize(naive_dt)
-            # Convert the timezone to UTC
-            value = aware_dt.astimezone(pytz.utc)
-        except (TypeError, dateutil.parser.ParserError):
+            # Convert timezone to UTC
+            value = aware_dt.astimezone(pytz.utc).replace(tzinfo=None)
+            # Apply final formatting
+            return value.replace(tzinfo=None).isoformat()
+        except (TypeError, ValueError):
             # String doesn't appear to be a date or time
             return value
-
-        if "date" in key and "time" not in key:
-            return str(value.date().isoformat())
-
-        if "time" in key and "date" not in key:
-            return str(value.time().isoformat())
-
-        return str(value.isoformat())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from chexus import BucketItem, TableItem
 
 
@@ -47,9 +49,9 @@ def test_table_item():
         "file_path": "path/to/somefile",
         "file_url": "www.example.com/content/path/to/somefile",
         "status": None,
-        "release_date": "2020-02-01",
-        "release_time": "05:30:00",
-        "release": "2020-02-01T05:30:00+00:00",
+        "release_date": "2020-02-01T05:00:00",
+        "release_time": "%sT05:30:00" % date.today(),
+        "release": "2020-02-01T05:30:00",
         "bad_datetime": "bats",
         "metadata": '{"some": {"thing": [4, 5, 6]}}',
     }


### PR DESCRIPTION
This commit changes the way datetimes are processed, seeing that full
ISO datetime strings are created for any parseable TableItem values.

Caught exceptions for datetime parsing were also modified, as dateutil's
ParserError is inaccessable.

TableItem model tests were updated according to the above changes.