### PR TITLE
Remove datetime conversions

### DIFF
--- a/chexus/_impl/models.py
+++ b/chexus/_impl/models.py
@@ -3,7 +3,6 @@ import json
 import os
 
 import dateutil
-import pytz
 
 
 class BucketItem(object):
@@ -67,10 +66,10 @@ class TableItem(object):
 
     Args:
         kwargs
-            Keyword arguments from which to create attributes.
+            Keyword arguments from which attributes are created.
             Dictionary values are converted to JSON strings.
             Values able to be parsed as dates and/or times are
-            converted to UTC timezone, ISO format datetime strings.
+            converted to ISO format datetime strings.
     """
 
     def __init__(self, **kwargs):
@@ -86,7 +85,7 @@ class TableItem(object):
 
     def _sanitize_value(self, value):
         # Coerce any dates, times to standard format
-        value = self._valid_datetime(value)
+        value = self._parse_datetime(value)
 
         # Serialize any dictionaries
         if isinstance(value, dict):
@@ -95,16 +94,9 @@ class TableItem(object):
         return value
 
     @staticmethod
-    def _valid_datetime(value):
+    def _parse_datetime(value):
         try:
-            # Parse string for datetime object
-            naive_dt = dateutil.parser.parse(value)
-            # Make datetime timezone-aware
-            aware_dt = pytz.timezone("US/Eastern").localize(naive_dt)
-            # Convert timezone to UTC
-            value = aware_dt.astimezone(pytz.utc).replace(tzinfo=None)
-            # Apply final formatting
-            return value.replace(tzinfo=None).isoformat()
+            return dateutil.parser.parse(value).isoformat()
         except (TypeError, ValueError):
             # String doesn't appear to be a date or time
             return value

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -65,9 +65,9 @@ def test_table_item():
         "file_path": "path/to/somefile",
         "file_url": "www.example.com/content/path/to/somefile",
         "status": None,
-        "release_date": "2020-02-01T05:00:00",
-        "release_time": "%sT04:30:00" % date.today(),
-        "release": "2020-02-01T05:30:00",
+        "release_date": "2020-02-01T00:00:00",
+        "release_time": "%sT00:30:00" % date.today(),
+        "release": "2020-02-01T00:30:00",
         "bad_datetime": "bats",
         "metadata": '{"some": {"thing": [4, 5, 6]}}',
     }


### PR DESCRIPTION
Previously, TableItem would attempt to localize any dates or times to
EST timezone before converting it to UTC timezone. This commit removes
timezone conversions, making the user responsible for providing accurate
times and dates.

Fixes #13