### PR TITLE
Implement remove methods

### DIFF
--- a/tests/client/test_download.py
+++ b/tests/client/test_download.py
@@ -87,7 +87,7 @@ def test_download_exceptions(caplog):
         client.download(item, "test_bucket")
 
     for msg in [
-        "One or more exceptions occurred during download",
+        "One or more exceptions occurred during last operation",
         "An error occurred (404) when calling the download operation: Unknown",
     ]:
         assert msg in caplog.text

--- a/tests/client/test_publish.py
+++ b/tests/client/test_publish.py
@@ -153,7 +153,7 @@ def test_publish_error(caplog):
     mocked_table.query.assert_called()
 
     for msg in [
-        "One or more exceptions occurred during publish",
+        "One or more exceptions occurred during last operation",
         "Something went wrong",
     ]:
         assert msg in caplog.text

--- a/tests/client/test_upload.py
+++ b/tests/client/test_upload.py
@@ -58,7 +58,7 @@ def test_upload(dryrun, caplog):
 
         # ...and proceeded with upload
         assert "Content already present in s3 bucket" not in caplog.text
-
+        print(mocked_bucket.upload_file.call_args_list)
         # Should've uploaded
         mocked_bucket.upload_file.assert_has_calls(
             upload_calls, any_order=True
@@ -140,7 +140,7 @@ def test_upload_exceptions(caplog):
         client.upload(items, "test_bucket")
 
     for msg in [
-        "One or more exceptions occurred during upload",
+        "One or more exceptions occurred during last operation",
         "Error uploading somefile3.txt",
         "Error uploading somefile2.txt",
     ]:


### PR DESCRIPTION
This commit introduces two new methods for removing content from an
Amazon S3 bucket and an Amazon DynamoDB table, remove_bucket_item and
remove_table_item. These methods accept BucketItems and TableItems,
respectively.